### PR TITLE
Aircan run status store, update, display features implemented.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ There are two potential cases:
 ### Local Airflow instance
  
 * In your`.env` file add  `CKAN__AIRFLOW__URL` according to [Apache AirFlow REST API Reference](https://airflow.apache.org/docs/stable/rest-api-ref#post--api-experimental-dags--DAG_ID--dag_runs). If you are running CKAN in a Docker container, make sure to specify the Airflow URL with `host.docker.internal` instead of `localhost`: `CKAN__AIRFLOW__URL=http://host.docker.internal:8080/api/experimental/dags/ckan_api_load_multiple_steps/dag_runs`. Also notice Airflow requires, by default, the endpoint `api/experimental/dags/DAG_ID` for API access.
+* Add Airflow admin username and password for authorization:
+  `CKAN__AIRFLOW__USERNAME=airflow_amin_username` and `CKAN__AIRFLOW__PASSWORD=airflow_admin_password`
 * Also in your `.env` file, specify a temporary directory for files: `CKAN__AIRFLOW__STORAGE_PATH=/tmp/` and `CKAN__AIRFLOW__CLOUD=local`. 
 
 ### Airflow instance on Google Composer

--- a/README.md
+++ b/README.md
@@ -84,34 +84,28 @@ The endpoint `http://YOUR-CKAN:5000/api/3/action/resource_create` produces the s
 CKAN__AIRFLOW__CLOUD__DAG_NAME=DAG_YOU_WANT_TO_TRIGGER
 ```
 
-### Retrieving a Workflow (DAG) status
-
-After submitting a POST request to `http://YOUR-CKAN:5000/api/3/action/aircan_submit?dag_name=ckan_api_load_gcp`, you should get a response that contains the `execution date` of the triggered DAG. For example:
-
+### Update aircan run status
+ The `aircan_status_update` API can be use to store or update the run status for given resource. It accepts the POST request with authorized user.
 ```json
-{
-
-    "help": "http://YOUR-CKAN:5000/api/3/action/help_show?name=aircan_submit",
-    "success": true,
-    "result": {
-        "aircan_status": {
-            "message": "Created <DagRun ckan_api_load_gcp @ 2020-08-12 00:56:59+00:00: manual__2020-08-12T00:56:59+00:00, externally triggered: True>"
-        }
+{ 
+    "resource_id": "a4a520aa-c790-4b53-93aa-de61e1a2813c",
+    "state": "progress",
+    "message":"Pusing dataset records.",
+    "dag_run_id":"394a1f0f-d8b3-47f2-9a51-08732349b785",
+    "error": {
+        "message" : "Failed to push data records."
     }
 }
 ```
 
-You can then hit `http://YOUR-CKAN:5000/api/3/action/aircan_status?dag_name=ckan_api_load_gcp` for a list of the most recent runs; or alternatively you can specify the execution date (the same you obtain on the response after triggering a DAG): `http://YOUR-CKAN:5000/api/3/action/aircan_status?dag_name=ckan_api_load_gcp&execution_date=2020-07-09T14:29:54`. Note you must specify two parameters: `dag_name` and `execution_date`.
-
-Then your response (assuming you specify an execution date) should be similar to:
+### Retrieving aircan run status 
+ Use `aircan_status` API to get aircan run status for given resource providing resource id.
+ eg.
+  `http://YOUR-CKAN:5000/api/3/action/aircan_status`
 
 ```json
 {
-    "help": "http://ckan:5000/api/3/action/help_show?name=aircan_status",
-    "success": true,
-    "result": {
-        "state": "failed"
-    }
+  "resource_id": "a4a520aa-c790-4b53-93aa-de61e1a2813c"
 }
 ```
 

--- a/ckanext/aircan_connector/logic/action.py
+++ b/ckanext/aircan_connector/logic/action.py
@@ -123,6 +123,9 @@ def aircan_submit(context, data_dict):
             ckan_airflow_endpoint_url = config.get('ckan.airflow.url')
             log.info("Airflow Endpoint URL: {0}".format(ckan_airflow_endpoint_url))
             response = requests.post(ckan_airflow_endpoint_url,
+                                     auth=requests.auth.HTTPBasicAuth( 
+                                        config['ckan.airflow.username'], 
+                                        config['ckan.airflow.password']),
                                      data=json.dumps(payload),
                                      headers={'Content-Type': 'application/json',
                                               'Cache-Control': 'no-cache'})

--- a/ckanext/aircan_connector/logic/action.py
+++ b/ckanext/aircan_connector/logic/action.py
@@ -78,11 +78,9 @@ def aircan_submit(context, data_dict):
         }
         '''
 
-        table_schema = ckan_resource.get('schema')
-        if not table_schema:    
-            raise ValueError()
+        table_schema = ckan_resource.get('schema', {})
         schema = json.dumps(table_schema)
-
+   
         # create giftless resource file uri to be passed to aircan
         pacakge_name = data_dict['pacakge_name']
         organization_name = data_dict['organization_name']

--- a/ckanext/aircan_connector/logic/action.py
+++ b/ckanext/aircan_connector/logic/action.py
@@ -1,17 +1,18 @@
 # encoding: utf-8
-import os
 import requests
 from datetime import date
 from ckan.common import config
 from ckan.plugins.toolkit import get_action, check_access
 import logging
 import json
-import time
-import urlparse
+import uuid
+import datetime
+
 from ckan.common import request
 from gcp_handler import GCPHandler
 from dag_status_report import DagStatusReport
 import ckan.logic as logic
+import ckan.plugins as p
 import ckan.lib.helpers as h
 
 REACHED_RESOPONSE  = False
@@ -21,6 +22,8 @@ log = logging.getLogger(__name__)
 
 ValidationError = logic.ValidationError
 NotFound = logic.NotFound
+_get_or_bust = logic.get_or_bust
+
 
 NO_SCHEMA_ERROR_MESSAGE = 'Resource <a href="{0}">{1}</a> has no schema so cannot be imported into the DataStore.'\
                         ' Please add a Table Schema in the resource schema attribute.'\
@@ -32,7 +35,7 @@ def aircan_submit(context, data_dict):
     log.info("Submitting resource via Aircan")
     check_access('aircan_submit', context, data_dict)
     try:
-        res_id = data_dict['resource_id']        
+        res_id = data_dict['resource_id']
         user = get_action('user_show')(context, {'id': context['user']})
         ckan_api_key = user['apikey']
         
@@ -80,7 +83,7 @@ def aircan_submit(context, data_dict):
 
         table_schema = ckan_resource.get('schema', {})
         schema = json.dumps(table_schema)
-   
+
         # create giftless resource file uri to be passed to aircan
         pacakge_name = data_dict['pacakge_name']
         organization_name = data_dict['organization_name']
@@ -91,7 +94,9 @@ def aircan_submit(context, data_dict):
 
         bq_table_name = ckan_resource.get('bq_table_name')
         log.debug("bq_table_name: {}".format(bq_table_name))
+        dag_run_id = str(uuid.uuid4())
         payload = { 
+            "dag_run_id": dag_run_id,
             "conf": {
                 "resource": {
                     "path": ckan_resource.get('url'),
@@ -139,6 +144,16 @@ def aircan_submit(context, data_dict):
                 config['ckan.airflow.cloud.dag_name'] = dag_name
             gcp_response = invoke_gcp(config, payload)
             AIRCAN_RESPONSE_AFTER_SUBMIT = {"aircan_status": gcp_response}
+
+        # Update the aircan run status
+        p.toolkit.get_action('aircan_status_update')(context,{ 
+            'dag_run_id': dag_run_id,
+            'resource_id': res_id,
+            'state': 'pending',
+            'message': 'Added to the queue to be processed.',
+            'clear_logs': True
+            })
+
     except ValueError:
         log.error(NO_SCHEMA_ERROR_MESSAGE)
         h.flash_error(NO_SCHEMA_ERROR_MESSAGE.format(ckan_resource_url , ckan_resource_name),  allow_html=True)
@@ -155,12 +170,114 @@ def invoke_gcp(config, payload):
     return gcp.trigger_dag()
 
 
-def dag_status(context, data_dict):
-    log.info(context)
-    check_access('aircan_status', context, data_dict)
-    dag_name = request.params.get('dag_name')
-    execution_date = request.params.get('execution_date', '')
-    dag_status_report = DagStatusReport(dag_name, execution_date, config)
+def aircan_dag_status(dag_name, dag_run_id):
+    dag_status_report = DagStatusReport(dag_name, dag_run_id, config)
     if config.get('ckan.airflow.cloud','local') != "GCP":
         return dag_status_report.get_local_aircan_report()
     return dag_status_report.get_gcp_report()
+
+def aircan_status(context, data_dict):
+    ''' Get the status of a aircan job for a certain resource.
+    :param resource_id: The resource id of the resource that you want the
+        aircan status for.
+    :type resource_id: string
+    '''
+    if 'id' in data_dict:
+        data_dict['resource_id'] = data_dict['id']
+    res_id = _get_or_bust(data_dict, 'resource_id')
+
+    task = p.toolkit.get_action('task_status_show')(context, {
+        'entity_id': res_id,
+        'task_type': 'aircan',
+        'key': 'aircan'
+    })
+    return_dict = {
+        'status': task['state'],
+        'last_updated': task['last_updated'],
+        'error': json.loads(task['error']),
+        'value': json.loads(task['value'])
+    }
+    return_dict.update(json.loads(task['value']))
+    return_dict.pop('value')
+    dag_run_id = return_dict.get('dag_run_id', False)
+    if dag_run_id:
+        try:
+            dag_status = aircan_dag_status(
+                    config.get('ckan.airflow.cloud.dag_name',
+                    'ckan_api_load_multiple_steps'), 
+                    dag_run_id)['airflow_api_aircan_status'] 
+
+            airflow_to_ckan_state = {
+                'queued': 'pending',
+                'running':'progress',
+                'success': 'complete',
+                'failed': 'error',
+                'up_for_retry': 'progress',
+                'upstream_failed': 'error'
+            }
+            return_dict['status'] = airflow_to_ckan_state.get(
+                    dag_status['state'], 
+                    return_dict['status']
+                    )
+            return_dict.update(dag_status)
+        except Exception as e:
+            log.error(e)
+    return return_dict
+
+def aircan_status_update(context, data_dict):
+    ''' Update the aircan dag status for a certain resource.
+    :param id: the id of the task status to update
+    :type id: string
+    :param resource_id:
+    :type resource_id: string
+    :param message: message string
+    :type message: string
+    :param state: (optional)
+    :type state:
+    :param last_updated: (optional)
+    :type last_updated:
+    :param error: (optional)
+    :type error:
+    :returns: the updated task status
+    :rtype: dictionary
+    '''
+
+    task_value = data_dict.get('value', {})
+    now_date = str(datetime.datetime.utcnow())
+
+    # Update dag_run_id in value
+    if data_dict.get('dag_run_id', False):
+        task_value.update({'dag_run_id': data_dict.get('dag_run_id')}) 
+
+    log_item = { 'datetime': now_date, 'message': data_dict.get('message', '')}
+    try:
+        old_task_status = p.toolkit.get_action('aircan_status')(
+            {}, {'resource_id': data_dict.get('resource_id', '')})
+
+        # Preserve old dag run id if new is not provided 
+        if not data_dict.get('dag_run_id') and \
+                old_task_status.get('dag_run_id', ''):
+            task_value.update({'dag_run_id': old_task_status.get('dag_run_id')}) 
+        
+        # Clear log and add new log if clear_logs is true
+        if data_dict.get('clear_logs', False):
+            old_task_status['logs'] = [log_item] 
+        # Append new log wihout distorying old one
+        elif old_task_status.get('logs', False):
+            old_task_status['logs'].append(log_item)
+
+        task_value.update({'logs': old_task_status['logs']})
+    except p.toolkit.ObjectNotFound:
+        task_value['logs'] = [log_item] 
+    task_dict =  {
+        'entity_id': data_dict.get('resource_id', ''),
+        'entity_type': 'resource',
+        'task_type': 'aircan',
+        'state': data_dict.get('state', ''),
+        'last_updated': data_dict.get('last_updated', now_date),
+        'key': 'aircan',
+        'value': json.dumps(task_value),
+        'error': json.dumps(data_dict.get('error', {})),
+    }
+    task_update = p.toolkit.get_action('task_status_update')(context, task_dict)
+    return task_update

--- a/ckanext/aircan_connector/logic/dag_status_report.py
+++ b/ckanext/aircan_connector/logic/dag_status_report.py
@@ -26,6 +26,9 @@ class DagStatusReport:
         ckan_airflow_endpoint_url = self.config.get('ckan.airflow.url')
         log.info("Airflow Endpoint URL: {0}".format(ckan_airflow_endpoint_url))
         response = requests.get(ckan_airflow_endpoint_url,
+                                auth=requests.auth.HTTPBasicAuth(
+                                        self.config['ckan.airflow.username'], 
+                                        self.config['ckan.airflow.password']),
                                  headers={'Content-Type': 'application/json',
                                           'Cache-Control': 'no-cache'})
         log.info(response.text)

--- a/ckanext/aircan_connector/logic/dag_status_report.py
+++ b/ckanext/aircan_connector/logic/dag_status_report.py
@@ -16,16 +16,16 @@ IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
 OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
 
 class DagStatusReport:
-    def __init__(self, dag_name, execution_date, config):
+    def __init__(self, dag_name, dag_run_id, config):
         self.dag_name = dag_name
         self.config = config
-        self.execution_date = ((str(execution_date)) if execution_date != '' else '')
+        self.dag_run_id = dag_run_id
 
     def get_local_aircan_report(self):
         log.info("Building Airflow local status report")
         ckan_airflow_endpoint_url = self.config.get('ckan.airflow.url')
-        log.info("Airflow Endpoint URL: {0}".format(ckan_airflow_endpoint_url))
-        response = requests.get(ckan_airflow_endpoint_url,
+        log.info("Airflow Endpoint URL: {0}/{1}".format(ckan_airflow_endpoint_url, self.dag_run_id))
+        response = requests.get('{0}/{1}'.format(ckan_airflow_endpoint_url, self.dag_run_id),
                                 auth=requests.auth.HTTPBasicAuth(
                                         self.config['ckan.airflow.username'], 
                                         self.config['ckan.airflow.password']),
@@ -46,8 +46,8 @@ class DagStatusReport:
             + webserver_id
             + '.composer.googleusercontent.com/api/v1/dags/'
             + self.dag_name
-            + '/dagRuns'
-            + '?execution_date_gte=' + (self.execution_date)
+            + '/dagRuns/'
+            + self.dag_run_id
         )
         log.info("The Webserver Url: {}".format(webserver_url))
         # Make a POST request to IAP which then Triggers the DAG

--- a/ckanext/aircan_connector/logic/helpers.py
+++ b/ckanext/aircan_connector/logic/helpers.py
@@ -1,0 +1,14 @@
+import logging
+import ckan.plugins.toolkit as toolkit
+
+
+log = logging.getLogger(__name__)
+
+def aircan_status(resource_id):
+    try:
+        return toolkit.get_action('aircan_status')(
+            {}, {'resource_id': resource_id})
+    except toolkit.ObjectNotFound:
+        return {
+            'status': 'unknown'
+        }

--- a/ckanext/aircan_connector/plugin.py
+++ b/ckanext/aircan_connector/plugin.py
@@ -5,7 +5,7 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as toolkit
 import ckan.model as model
 from ckanext.aircan_connector import  blueprint
-from ckanext.aircan_connector import action
+from ckanext.aircan_connector.logic import action, auth
 from ckanext.aircan_connector import helpers
 log = logging.getLogger(__name__)
 
@@ -113,6 +113,14 @@ class Aircan_ConnectorPlugin(p.SingletonPlugin):
     # IBlueprint
     def get_blueprint(self):
        return blueprint.aircan
+
+    # IAuthFunctions
+    def get_auth_functions(self):
+        return {
+            'aircan_submit': auth.aircan_submit,
+            'aircan_status': auth.aircan_status
+        }
+
     
     #ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/aircan_connector/plugin.py
+++ b/ckanext/aircan_connector/plugin.py
@@ -103,7 +103,8 @@ class Aircan_ConnectorPlugin(p.SingletonPlugin):
     def get_actions(self):
         return {
             'aircan_submit': action.aircan_submit,
-            'aircan_status': action.dag_status
+            'aircan_status': action.aircan_status,
+            'aircan_status_update': action.aircan_status_update
         }
 
 

--- a/ckanext/aircan_connector/plugin.py
+++ b/ckanext/aircan_connector/plugin.py
@@ -5,7 +5,8 @@ import ckan.plugins as p
 import ckan.plugins.toolkit as toolkit
 import ckan.model as model
 from ckanext.aircan_connector import  blueprint
-from ckanext.aircan_connector.logic import action, auth
+from ckanext.aircan_connector import action
+from ckanext.aircan_connector import helpers
 log = logging.getLogger(__name__)
 
 
@@ -27,6 +28,7 @@ class Aircan_ConnectorPlugin(p.SingletonPlugin):
     p.implements(p.IAuthFunctions)
     p.implements(p.IBlueprint)
     p.implements(p.IActions)
+    p.implements(p.ITemplateHelpers)
     p.implements(p.IResourceController, inherit=True)
 
     # IConfigurer
@@ -111,10 +113,9 @@ class Aircan_ConnectorPlugin(p.SingletonPlugin):
     # IBlueprint
     def get_blueprint(self):
        return blueprint.aircan
-
-    # IAuthFunctions
-    def get_auth_functions(self):
+    
+    #ITemplateHelpers
+    def get_helpers(self):
         return {
-            'aircan_submit': auth.aircan_submit,
-            'aircan_status': auth.aircan_status
+            'aircan_status': helpers.aircan_status
         }

--- a/ckanext/aircan_connector/plugin.py
+++ b/ckanext/aircan_connector/plugin.py
@@ -25,7 +25,7 @@ class Aircan_ConnectorPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer, inherit=True)
     p.implements(p.IResourceUrlChange)
     p.implements(p.IAuthFunctions)
-    #p.implements(p.IBlueprint)
+    p.implements(p.IBlueprint)
     p.implements(p.IActions)
     p.implements(p.IResourceController, inherit=True)
 

--- a/ckanext/aircan_connector/templates/package/resource_edit_base.html
+++ b/ckanext/aircan_connector/templates/package/resource_edit_base.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block inner_primary_nav %}
+  {{ super() }}
+  {{ h.build_nav_icon('aircan.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}
+{% endblock %}

--- a/ckanext/aircan_connector/templates/resource_data.html
+++ b/ckanext/aircan_connector/templates/resource_data.html
@@ -1,0 +1,66 @@
+{% extends "package/resource_edit_base.html" %}
+
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock %}
+
+{% block primary_content_inner %}
+
+  {% set action = h.url_for('aircan.resource_data', id=pkg.name, resource_id=res.id) %}
+  {% set show_table = true %}
+
+  {% if status.error and status.error.message %}
+    <div class="alert alert-error">
+      <strong>{{ _('Upload error:') }}</strong> {{ status.error.message }}
+    </div>
+  {% endif %}
+
+  <form method="post" action="{{ action }}" class="datapusher-form">
+    <button class="btn btn-primary" name="save" type="submit">
+      <i class="fa fa-cloud-upload"></i> {{ _('Upload to DataStore') }}
+    </button>
+  </form>
+  <table class="table table-bordered">
+    <colgroup>
+      <col width="150">
+      <col>
+    </colgroup>
+    <tr>
+      <th>{{ _('Status') }}</th>
+      <td>{{ status['status'] }}</td>
+    </tr>
+    <tr>
+      <th>{{ _('Last updated') }}</th>
+      {% if status.status %}
+        <td><span class="date" title="{{ h.render_datetime(status.last_updated, with_hours=True) }}">{{ h.time_ago_from_timestamp(status.last_updated) }}</span></td>
+      {% else %}
+        <td>{{ _('Never') }}</td>
+      {% endif %}
+    </tr>
+  </table>
+  {% if status.status and status.logs and show_table %}
+  <h3>{{ _('Upload Log') }}</h3>
+  <ul class="activity">
+    {% for item in status.logs|sort(attribute='datetime') %}
+    {% set icon = 'pencil' %}
+    {% set class = ' success' %}
+      {% set popover_content = 'test' %}
+      <li class="item no-avatar{{ class }}">
+        <i class="fa icon fa-{{ icon }}"></i>
+        <p>
+          {% for line in item.message.strip().split('\n') %}
+            {{ line | urlize }}<br>
+          {% endfor %}
+          <span class="date" title="{{ h.render_datetime(item.datetime, with_hours=True) }}">
+            {{ h.time_ago_from_timestamp(item.datetime) }}
+            <a href="#" data-target="popover" data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ h.clean_html(value|string) }}</dd>{% endfor %}</dl>" data-html="true">{{ _('Details') }}</a>
+          </span>
+        </p>
+      </li>
+    {% endfor %}
+    <li class="item no-avatar">
+      <i class="fa icon fa-info"></i>
+      <p class="muted">{{ _('End of log') }}</p>
+    </li>
+  </ul>
+  {% endif %}
+  
+{% endblock %}


### PR DESCRIPTION
This PR includes the following changes.
-  User authorization environment variable added for local Airflow v2 . Airflow v2 expects mandatory user authorization. 
- Aircan submits or Dag submits with predefine dag_run_id so that run status can be retrieved later. (_Depreciated_: Get run status with execution  date is depreciated.)
- Aircan API `aircan_status_update` is implemented to store, and update run status with historical activity and messages.  This API can be called from Aircan Dag whenever the status needs to be updated with activity messages. 
   eg. payload
  ```json
  { 
      "resource_id": "a4a520aa-c790-4b53-93aa-de61e1a2813c",
      "state": "progress",
      "message":"The process in queue",
      "dag_run_id":"394a1f0f-d8b3-47f2-9a51-08732349b785",
      "error": {
          "message": "Failed to push dataset."
      }
  }
  ```
  - Aircan API `aircan_status` is implemented to retrieve the status from both CKAN log save status and Airflow service. 
    eg. response
      ```json
      {
            "status": "error",
            "last_updated": "2022-07-24T02:03:55.383310",
            "logs": [
                {
                    "message": "Added to the queue to be processed.",
                    "datetime": "2022-07-24 02:03:01.314942"
                },
                {
                    "message": "Deleting existing table.",
                    "datetime": "2022-07-24 02:03:13.834957"
                },
                {
                    "message": "Determing table headers from data file.",
                    "datetime": "2022-07-24 02:03:27.086856"
                },
                {
                    "message": "Failed to push data into datastore DB.",
                    "datetime": "2022-07-24 02:03:55.397458"
                }
            ],
            "end_date": "2022-07-24T02:04:01.387387+00:00",
            "execution_date": "2022-07-24T02:03:01.281425+00:00",
            "external_trigger": true,
            "state": "failed",
            "logical_date": "2022-07-24T02:03:01.281425+00:00",
            "conf": {
                ....
            },
            "error": {
                "message": "sfsdfsdfd"
            },
            "dag_run_id": "a6bdc639-a93e-4a67-8bdc-693f8d15696b",
            "start_date": "2022-07-24T02:03:06.498662+00:00",
            "dag_id": "ckan_api_load_multiple_steps"
        }
      ```
- Blueprint path added and templates updated to display the aircan run status in UI.
   -  `/dataset/<dataset_id>/resource_data/<resource_id>` page added where users can resubmit the data to aircan and also see the logs 
   -  <img width="1235" alt="Screen Shot 2022-07-24 at 9 38 06 AM" src="https://user-images.githubusercontent.com/87696933/180631416-e1fee213-d9aa-49b8-b12b-54803d324ad4.png">
   
- Helper function`h.aircan_status(res_id)` added for displaying aircan status in  tempaltes.

NOTE: Only tested with `ckan_api_load_multiple_steps` Dags and airflow v2.2.5.
